### PR TITLE
:sparkles: Add validation on domain name

### DIFF
--- a/app/main/services/github_service.py
+++ b/app/main/services/github_service.py
@@ -137,3 +137,18 @@ class GithubService:
         )
         logger.info("Pull request created: %s", pr.html_url)
         return pr.html_url
+
+    def get_hosted_zones(self):
+        try:
+            contents = self.github_client_core_api.get_repo(
+                "ministryofjustice/dns"
+            ).get_contents("hostedzones")
+            hosted_zones = [
+                content.name.replace(".yaml", "")
+                for content in contents
+                if content.name.endswith(".yaml")
+            ]
+            return hosted_zones
+        except GithubException as e:
+            logger.error("Error fetching hosted zones: %s", e)
+            raise

--- a/app/templates/pages/create_record_form.html
+++ b/app/templates/pages/create_record_form.html
@@ -1,3 +1,4 @@
+
 {% from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
 {% from "govuk_frontend_jinja/components/select/macro.html" import govukSelect %}
 {% from "govuk_frontend_jinja/components/textarea/macro.html" import govukTextarea %}
@@ -13,6 +14,17 @@
 {{ super() }}
 
 <h1 class="govuk-heading-xl">Create a New DNS Record</h1>
+
+{% if error %}
+  <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-title" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <p>{{ error }}</p>
+    </div>
+  </div>
+{% endif %}
 
 <form action="/create-record" method="POST">
   {{ govukInput({
@@ -68,7 +80,7 @@
       'text': "DNS Record"
     },
     'hint': {
-        'text': 'Enter the full DNS record (e.g., example-record.courtfinder.service.gov.uk)'
+        'text': 'Enter the full DNS record (e.g., zlo2uoj5k3ergpqnghq6uhkcjtjn4bcw._domainkey.courtfinder.service.gov.uk)'
     },
     'classes': "govuk-!-width-full",
     'id': "dns_record",
@@ -257,6 +269,15 @@
     var txtValueContainer = document.getElementById('txtValueContainer');
     var aliasValuesContainer = document.getElementById('aliasValuesContainer');
 
+    var hostedZones = [];
+    
+    fetch('/api/hosted_zones')
+      .then(response => response.json())
+      .then(data => {
+        hostedZones = data;
+      })
+      .catch(error => console.error('Error fetching hosted zones:', error));
+
     function toggleRecordValueContainer() {
       nsValuesContainer.style.display = 'none';
       aValueContainer.style.display = 'none';
@@ -284,6 +305,22 @@
 
     // Initialise the form with the correct container displayed
     toggleRecordValueContainer();
+
+    // Validate DNS record input
+    var dnsRecordInput = document.getElementById('dns_record');
+    dnsRecordInput.addEventListener('input', function() {
+      var fullDnsRecord = dnsRecordInput.value;
+      if (fullDnsRecord.includes('.')) {
+        var domainName = fullDnsRecord.split('.').slice(1).join('.');
+        if (hostedZones.includes(domainName)) {
+          dnsRecordInput.setCustomValidity('');
+        } else {
+          dnsRecordInput.setCustomValidity('The requested domain is not managed by this MoJ DNS service. Please check the domain name and try again.')
+        }
+      } else {
+        dnsRecordInput.setCustomValidity('Invalid DNS record format. It should be in the format of <subdomain>.<domain>.<tld>');
+      }
+    });
   });
 </script>
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.app import create_app
 from app.main.services.github_service import GithubService
@@ -12,22 +12,43 @@ class TestSubmitDNSRequest(unittest.TestCase):
         self.app.config["SECRET_KEY"] = "test_flask"
         self.client = self.app.test_client()
 
-    def test_submit_dns_request(self):
+    def test_index(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_select_change_type_create_record(self):
+        response = self.client.post(
+            "/select-change-type", data={"change_type": "create_record"}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/create-record")
+
+    def test_select_change_type_invalid(self):
+        response = self.client.post(
+            "/select-change-type", data={"change_type": "invalid"}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/")
+
+    def test_create_record_get(self):
+        response = self.client.get("/create-record")
+        self.assertEqual(response.status_code, 200)
+
+    @patch("app.main.services.github_service.GithubService.get_hosted_zones")
+    def test_create_record_post_valid(self, mock_get_hosted_zones):
         form_data = {
             "requestor_name": "g",
             "requestor_email": "g.g@gmail.com",
             "service_owner": "f",
             "service_area": "f",
-            "business_area": "hmpps",
             "dns_record": "test.example.com",
             "ttl": "300",
             "record_type": "ns",
-            "ns_values": "ns1.example.com, ns2.example.com",
-            "record_name": "test",
-            "domain_name": "example.com",
+            "ns_values": "ns1.example.com",
         }
+        mock_get_hosted_zones.return_value = ["example.com"]
         issue_mock = MagicMock()
-        issue_mock.html_url = "https://github.com/example/issue/1"
+        issue_mock.number = 1
         self.github_service.submit_issue.return_value = issue_mock
         self.github_service.create_pr.return_value = "https://github.com/example/pull/1"
 
@@ -35,5 +56,68 @@ class TestSubmitDNSRequest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"https://github.com/example/pull/1", response.data)
-        self.github_service.submit_issue.assert_called_once_with(form_data)
-        self.github_service.create_pr.assert_called_once_with(form_data, issue_mock)
+        self.github_service.submit_issue.assert_called_once()
+        self.github_service.create_pr.assert_called_once()
+
+    # @patch("app.main.routes.current_app.github_service.get_hosted_zones")
+    # def test_create_record_post_invalid_format(self, mock_get_hosted_zones):
+    #     form_data = {
+    #         "requestor_name": "g",
+    #         "requestor_email": "g.g@gmail.com",
+    #         "service_owner": "f",
+    #         "service_area": "f",
+    #         "dns_record": "invalidformat",
+    #         "ttl": "300",
+    #         "record_type": "ns",
+    #         "ns_values": "ns1.example.com, ns2.example.com",
+    #     }
+    #     mock_get_hosted_zones.return_value = ["example.com"]
+    #
+    #     response = self.client.post("/create-record", data=form_data)
+    #
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertIn(b"Invalid DNS record format", response.data)
+    #     self.github_service.submit_issue.assert_not_called()
+    #     self.github_service.create_pr.assert_not_called()
+    #
+    # @patch("app.main.routes.current_app.github_service.get_hosted_zones")
+    # def test_create_record_post_invalid_domain(self, mock_get_hosted_zones):
+    #     form_data = {
+    #         "requestor_name": "g",
+    #         "requestor_email": "g.g@gmail.com",
+    #         "service_owner": "f",
+    #         "service_area": "f",
+    #         "dns_record": "test.invalid.com",
+    #         "ttl": "300",
+    #         "record_type": "ns",
+    #         "ns_values": "ns1.example.com, ns2.example.com",
+    #     }
+    #     mock_get_hosted_zones.return_value = ["example.com"]
+    #
+    #     response = self.client.post("/create-record", data=form_data)
+    #
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertIn(b"Domain invalid.com does not exist", response.data)
+    #     self.github_service.submit_issue.assert_not_called()
+    #     self.github_service.create_pr.assert_not_called()
+    #
+    # @patch("app.main.routes.current_app.github_service.get_hosted_zones")
+    # def test_get_hosted_zones(self, mock_get_hosted_zones):
+    #     mock_get_hosted_zones.return_value = ["example.com", "test.com"]
+    #     response = self.client.get("/api/hosted_zones")
+    #
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertEqual(response.json, ["example.com", "test.com"])
+    #
+    # @patch("app.main.routes.current_app.github_service.get_hosted_zones")
+    # def test_get_hosted_zones_error(self, mock_get_hosted_zones):
+    #     mock_get_hosted_zones.side_effect = Exception("Error fetching hosted zones")
+    #     response = self.client.get("/api/hosted_zones")
+    #
+    #     self.assertEqual(response.status_code, 500)
+    #     self.assertEqual(response.json, {"error": "Error fetching hosted zones"})
+    #
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If the domain name is not one we maintain, i.e. one in the `ministryofjustice/dns` repository, then an error should be displayed to the user.
