### PR TITLE
:arrow_up: Bump flask-cors version to 5.0.0 to mitigate CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Deprecated==1.2.14
 dnspython==2.6.1
 email-validator==2.1.0.post1
 Flask==3.0.2
-Flask-Cors==4.0.1
+Flask-Cors==5.0.0
 Flask-Limiter==3.5.0
 govuk-frontend-jinja==3.0.0
 gunicorn==22.0.0


### PR DESCRIPTION
This CVE was reported in: https://github.com/ministryofjustice/operations-engineering-dns-form/security/dependabot/5 and relates to a setting we don't actually use, but is swtiched on by default.
