### PR TITLE
🚀 Set up Production Environment

### DIFF
--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -6,16 +6,18 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 env:
+  KUBE_CERT: ${{ secrets.PROD_KUBE_CERT }}
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.PROD_KUBE_NAMESPACE }}
-  KUBE_CERT: ${{ secrets.PROD_KUBE_CERT }}
   KUBE_TOKEN: ${{ secrets.PROD_KUBE_TOKEN }}
 
-  IMAGE_TAG: ${{ github.ref_name }}
-  ECR_REGISTRY: ${{ vars.PROD_ECR_REGISTRY }}
+  ECR_REGISTRY: ${{ secrets.ECR_REGISTRY_URL }}
   ECR_REPOSITORY: ${{ vars.PROD_ECR_REPOSITORY }}
+  IMAGE_TAG: ${{ github.ref_name }}
 
-  ADMIN_GITHUB_TOKEN: ${{ secrets.PROD_ADMIN_GITHUB_TOKEN }}
+  ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+  AUTH0_CLIENT_ID: ${{ secrets.PROD_AUTH0_CLIENT_ID }}
+  AUTH0_CLIENT_SECRET: ${{ secrets.PROD_AUTH0_CLIENT_SECRET }}
   FLASK_APP_SECRET: ${{ secrets.PROD_FLASK_APP_SECRET }}
   SENTRY_DSN_KEY: ${{secrets.SENTRY_DSN_KEY }}
 
@@ -38,7 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.PROD_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.PROD_ECR_REGION }}
 
-      - uses: aws-actions/amazon-ecr-login@v2
+      - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         id: login-ecr
       - run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
@@ -71,6 +73,8 @@ jobs:
             --wait \
             --namespace ${KUBE_NAMESPACE} \
             --values=helm/dns-form/values-prod.yaml \
+            --set app.deployment.env.AUTH0_CLIENT_ID=${AUTH0_CLIENT_ID} \
+            --set app.deployment.env.AUTH0_CLIENT_SECRET=${AUTH0_CLIENT_SECRET} \
             --set app.deployment.env.APP_SECRET_KEY=${FLASK_APP_SECRET} \
             --set app.deployment.env.ADMIN_GITHUB_TOKEN=${ADMIN_GITHUB_TOKEN} \
             --set app.deployment.env.SENTRY_DSN_KEY=${SENTRY_DSN_KEY} \

--- a/helm/dns-form/values-prod.yaml
+++ b/helm/dns-form/values-prod.yaml
@@ -1,6 +1,6 @@
 app:
   ingress:
-    host: "dns-form.service.justice.gov.uk"
+    host: "change-dns.service.justice.gov.uk"
 
   deployment:
     replicaCount: 3


### PR DESCRIPTION
This pull request includes several updates to the CI/CD deployment process and configuration for the production environment. The most important changes involve updating secrets and variables in the workflow file and modifying the Helm chart values for the production deployment.

### CI/CD Workflow Updates:

* [`.github/workflows/cicd-deploy-to-prod.yml`](diffhunk://#diff-38d1afab879f00ee2981b026cb0e62a6cff50f90f2cbac1bee092bda963a8f34R9-R20): Updated the secrets and variables to use the correct production values, including `ECR_REGISTRY_URL`, `ADMIN_GITHUB_TOKEN`, `AUTH0_CLIENT_ID`, and `AUTH0_CLIENT_SECRET`.
* [`.github/workflows/cicd-deploy-to-prod.yml`](diffhunk://#diff-38d1afab879f00ee2981b026cb0e62a6cff50f90f2cbac1bee092bda963a8f34L41-R43): Changed the `aws-actions/amazon-ecr-login` action to use a specific commit hash for version `v2.0.1`.
* [`.github/workflows/cicd-deploy-to-prod.yml`](diffhunk://#diff-38d1afab879f00ee2981b026cb0e62a6cff50f90f2cbac1bee092bda963a8f34R76-R77): Added `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET` to the Helm deployment command.

### Helm Chart Updates:

* [`helm/dns-form/values-prod.yaml`](diffhunk://#diff-eb49d3f7151a2ff6d8fd21548e76dddca5c6e58abcae7c9cee4159f0292338ddL3-R3): Updated the ingress host to "change-dns.service.justice.gov.uk".