### PR TITLE
🔧 Fix Prod Environment

### DIFF
--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -5,16 +5,16 @@ on:
   push:
     branches: [main]
 env:
+  KUBE_CERT: ${{ secrets.DEV_KUBE_CERT }}
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.DEV_KUBE_NAMESPACE }}
-  KUBE_CERT: ${{ secrets.DEV_KUBE_CERT }}
   KUBE_TOKEN: ${{ secrets.DEV_KUBE_TOKEN }}
 
-  IMAGE_TAG: ${{ github.sha }}
   ECR_REGISTRY: ${{ vars.DEV_ECR_REGISTRY }}
   ECR_REPOSITORY: ${{ vars.DEV_ECR_REPOSITORY }}
+  IMAGE_TAG: ${{ github.sha }}
+
   ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-  ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SLACK_TOKEN }}
   AUTH0_CLIENT_ID: ${{ secrets.DEV_AUTH0_CLIENT_ID }}
   AUTH0_CLIENT_SECRET: ${{ secrets.DEV_AUTH0_CLIENT_SECRET }}
   FLASK_APP_SECRET: ${{ secrets.DEV_FLASK_APP_SECRET }}
@@ -29,13 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@486457dc46e82b9a740ca0ef1dac6a38a3fc272d # v4.0.2
         with:
           role-to-assume: ${{ secrets.DEV_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.DEV_ECR_REGION }}
 
-      - uses: aws-actions/amazon-ecr-login@v2
-        id: login-ecr
+      - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       - run: |
           docker build -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" .
           docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
@@ -71,7 +70,6 @@ jobs:
             --set app.deployment.env.AUTH0_CLIENT_SECRET=${AUTH0_CLIENT_SECRET} \
             --set app.deployment.env.APP_SECRET_KEY="${FLASK_APP_SECRET}" \
             --set app.deployment.env.ADMIN_GITHUB_TOKEN="${ADMIN_GITHUB_TOKEN}" \
-            --set app.deployment.env.ADMIN_SLACK_TOKEN="${ADMIN_SLACK_TOKEN}" \
             --set app.deployment.env.SENTRY_DSN_KEY="${SENTRY_DSN_KEY}" \
             --set app.deployment.image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
             --set app.deployment.image.tag="${IMAGE_TAG}"

--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -9,7 +9,7 @@ env:
   KUBE_CERT: ${{ secrets.PROD_KUBE_CERT }}
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.PROD_KUBE_NAMESPACE }}
-  KUBE_TOKEN: ${{ secrets.PROD_KUBE_TOKEN }}
+  KUBE_TOKEN: ${{ secrets.PROD_DEV_KUBE_TOKEN }}
 
   ECR_REGISTRY: ${{ secrets.ECR_REGISTRY_URL }}
   ECR_REPOSITORY: ${{ vars.PROD_ECR_REPOSITORY }}
@@ -31,17 +31,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@d1798aa3dc45a3eb4258be26641b43ef01552715 # v2.0.8
         with:
           generate_release_notes: true
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@486457dc46e82b9a740ca0ef1dac6a38a3fc272d # v4.0.2
         with:
           role-to-assume: ${{ secrets.PROD_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.PROD_ECR_REGION }}
 
       - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-        id: login-ecr
       - run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/helm/dns-form/values-prod.yaml
+++ b/helm/dns-form/values-prod.yaml
@@ -5,6 +5,7 @@ app:
   deployment:
     replicaCount: 3
     env:
+      AUTH0_DOMAIN: "operations-engineering.eu.auth0.com"
       SENTRY_ENV: "production"
       FLASK_DEBUG: false
       PHASE_BANNER_TEXT: "PRIVATE BETA"


### PR DESCRIPTION
The most interesting part of this PR is the rename of an environment variable `PROD_DEV_KUBE_TOKEN`. For some reason CP name this variable incorrectly, which caused me to troubleshoot our deployment for over 2 hrs. Hey Ho.

This pull request includes updates to the CI/CD workflows and Helm chart configurations for both development and production environments. The most important changes include updating environment variables, modifying the versions of GitHub Actions used, and removing unused tokens.

### CI/CD Workflow Updates

* [`.github/workflows/cicd-deploy-to-dev.yml`](diffhunk://#diff-127b01e08167ddb3c5ad362d3219d8d42205202970cb1dd5dc4054892d431f02R8-L17): Updated the order of environment variables and removed the `ADMIN_SLACK_TOKEN`. Also, pinned specific versions for `aws-actions/configure-aws-credentials` and `aws-actions/amazon-ecr-login` actions. [[1]](diffhunk://#diff-127b01e08167ddb3c5ad362d3219d8d42205202970cb1dd5dc4054892d431f02R8-L17) [[2]](diffhunk://#diff-127b01e08167ddb3c5ad362d3219d8d42205202970cb1dd5dc4054892d431f02L32-R37) [[3]](diffhunk://#diff-127b01e08167ddb3c5ad362d3219d8d42205202970cb1dd5dc4054892d431f02L74)
* [`.github/workflows/cicd-deploy-to-prod.yml`](diffhunk://#diff-38d1afab879f00ee2981b026cb0e62a6cff50f90f2cbac1bee092bda963a8f34L12-R12): Corrected the `KUBE_TOKEN` environment variable to use `PROD_DEV_KUBE_TOKEN` and pinned specific versions for `softprops/action-gh-release`, `aws-actions/configure-aws-credentials`, and `aws-actions/amazon-ecr-login` actions. [[1]](diffhunk://#diff-38d1afab879f00ee2981b026cb0e62a6cff50f90f2cbac1bee092bda963a8f34L12-R12) [[2]](diffhunk://#diff-38d1afab879f00ee2981b026cb0e62a6cff50f90f2cbac1bee092bda963a8f34L34-L44)

### Helm Chart Configuration

* [`helm/dns-form/values-prod.yaml`](diffhunk://#diff-eb49d3f7151a2ff6d8fd21548e76dddca5c6e58abcae7c9cee4159f0292338ddR8): Added the `AUTH0_DOMAIN` environment variable for production deployments.